### PR TITLE
Migrate to cw-assets v3 and cw-storage-plus v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "alliance-hub"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "alliance-protocol",
  "cosmwasm-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,11 +21,13 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-asset",
+ "cw-asset 2.4.0",
+ "cw-asset 3.1.1",
  "cw-storage-plus 0.16.0",
+ "cw-storage-plus 1.2.0",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.1.1",
+ "cw2 1.1.2",
+ "cw20 1.1.2",
  "cw20-base",
  "schemars",
  "semver",
@@ -42,9 +44,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-asset",
+ "cw-asset 2.4.0",
  "cw-storage-plus 0.16.0",
- "cw2 1.0.1",
+ "cw2 1.1.2",
  "schemars",
  "serde",
  "terra-proto-rs",
@@ -58,9 +60,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-asset",
- "cw-storage-plus 0.16.0",
- "cw20 1.1.1",
+ "cw-asset 2.4.0",
+ "cw-asset 3.1.1",
+ "cw20 1.1.2",
  "schemars",
  "serde",
  "thiserror",
@@ -97,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128a44527fc0d6abf05f9eda748b9027536e12dff93f5acc8449f51583309350"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "bumpalo"
@@ -155,11 +163,12 @@ checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.4.1"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fb22494cf7d23d0c348740e06e5c742070b2991fd41db77bba0bcfbae1a723"
+checksum = "dd50718a2b6830ce9eb5d465de5a018a12e71729d66b70807ce97e6dd14f931d"
 dependencies = [
  "digest 0.10.7",
+ "ecdsa",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.4",
@@ -168,18 +177,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.4.1"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e199424486ea97d6b211db6387fd72e26b4a439d40cc23140b2d8305728055b"
+checksum = "242e98e7a231c122e08f300d9db3262d1007b51758a8732cd6210b3e9faa4f3a"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.4.1"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef683a9c1c4eabd6d31515719d0d2cc66952c4c87f7eb192bfc90384517dc34"
+checksum = "7879036156092ad1c22fe0d7316efc5a5eceec2bc3906462a2560215f2a2f929"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -190,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.4.1"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9567025acbb4c0c008178393eb53b3ac3c2e492c25949d3bf415b9cbe80772d8"
+checksum = "0bb57855fbfc83327f8445ae0d413b1a05ac0d68c396ab4d122b2abd7bb82cb6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -201,11 +210,12 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.4.1"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d89d680fb60439b7c5947b15f9c84b961b88d1f8a3b20c4bd178a3f87db8bae"
+checksum = "78c1556156fdf892a55cced6115968b961eaaadd6f724a2c2cb7d1e168e32dd3"
 dependencies = [
  "base64",
+ "bech32",
  "bnum",
  "cosmwasm-crypto",
  "cosmwasm-derive",
@@ -216,6 +226,7 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "sha2 0.10.6",
+ "static_assertions",
  "thiserror",
 ]
 
@@ -274,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-address-like"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451a4691083a88a3c0630a8a88799e9d4cd6679b7ce8ff22b8da2873ff31d380"
+dependencies = [
+ "cosmwasm-std",
+]
+
+[[package]]
 name = "cw-asset"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +304,20 @@ dependencies = [
  "cw-storage-plus 0.16.0",
  "cw1155",
  "cw20 0.16.0",
+]
+
+[[package]]
+name = "cw-asset"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c999a12f8cd8736f6f86e9a4ede5905530cb23cfdef946b9da1c506ad1b70799"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-address-like",
+ "cw-storage-plus 1.2.0",
+ "cw20 1.1.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -299,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0e92a069d62067f3472c62e30adedb4cab1754725c0f2a682b3128d2bf3c79"
+checksum = "d5ff29294ee99373e2cd5fd21786a3c0ced99a52fec2ca347d565489c61b723c"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -331,7 +365,7 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.1",
+ "cw2 1.1.2",
  "schemars",
  "semver",
  "serde",
@@ -366,15 +400,17 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb70cee2cf0b4a8ff7253e6bc6647107905e8eb37208f87d54f67810faa62f8"
+checksum = "c6c120b24fbbf5c3bedebb97f2cc85fbfa1c3287e09223428e7e597b5293c1fa"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "schemars",
+ "semver",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -392,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786e9da5e937f473cecd2463e81384c1af65d0f6398bbd851be7655487c55492"
+checksum = "526e39bb20534e25a1cd0386727f0038f4da294e5e535729ba3ef54055246abd"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -411,10 +447,10 @@ checksum = "afcd279230b08ed8afd8be5828221622bd5b9ce25d0b01d58bad626c6ce0169c"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
+ "cw-storage-plus 1.2.0",
  "cw-utils 1.0.1",
- "cw2 1.0.1",
- "cw20 1.1.1",
+ "cw2 1.1.2",
+ "cw20 1.1.2",
  "schemars",
  "semver",
  "serde",
@@ -707,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
 ]
@@ -748,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -841,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
 dependencies = [
  "serde",
 ]
@@ -865,7 +901,7 @@ checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -935,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1003,22 +1045,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1091,7 +1133,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -1113,7 +1155,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 exclude = []
 
 [workspace.package]
-version       = "0.1.0"
+version       = "0.1.1"
 edition       = "2021"
 license       = "Apache-2.0"
 repository    = "https://github.com/terra-money/alliance-protocol"
@@ -30,17 +30,19 @@ incremental = false
 overflow-checks = false
 
 [workspace.dependencies]
-cosmwasm-std = "1.1.10"
+cosmwasm-std = "1.5.5"
 cosmwasm-storage = "1.1.10"
-cosmwasm-schema = "1.1.10"
-cw-storage-plus = "0.16.0"
-cw-asset = "2.4.0"
+cosmwasm-schema = "1.5.5"
+cw_storage_plus_016 = { package = "cw-storage-plus", version = "0.16.0" }
+cw_storage_plus_120 = { package = "cw-storage-plus", version = "1.2.0" }
+cw_asset_v3 = { package = "cw-asset", version = "3.1.1" }
+cw_asset_v2 = { package = "cw-asset", version = "2.4.0" }
 schemars = "0.8.11"
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 terra-proto-rs = { version = "3.0.1", default-features = false}
 thiserror = { version = "1.0.38" }
-cw2 = "1.0.1"
-cw20 ="1.0.1"
+cw2 = "1.1.2"
+cw20 ="1.1.2"
 semver = "1.0.22"
 
 alliance-protocol = { path = "./packages/alliance-protocol" }

--- a/contracts/alliance-hub/Cargo.toml
+++ b/contracts/alliance-hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alliance-hub"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Terra Money <core@terra.money>"]
 edition = "2018"
 

--- a/contracts/alliance-hub/Cargo.toml
+++ b/contracts/alliance-hub/Cargo.toml
@@ -20,8 +20,10 @@ library = []
 cosmwasm-std = { workspace = true, features = ["stargate"] }
 cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cw-storage-plus = { workspace = true }
-cw-asset = { workspace = true }
+cw_storage_plus_016 = { workspace = true }
+cw_storage_plus_120 = { workspace = true }
+cw_asset_v2 = { workspace = true }
+cw_asset_v3 = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/contracts/alliance-hub/src/contract.rs
+++ b/contracts/alliance-hub/src/contract.rs
@@ -219,8 +219,8 @@ fn whitelist_assets(
     let mut attrs = vec![("action".to_string(), "whitelist_assets".to_string())];
     for (chain_id, assets) in &assets_request {
         for asset in assets {
-            WHITELIST.save(deps.storage, &asset, chain_id)?;
-            ASSET_REWARD_RATE.update(deps.storage, &asset, |rate| -> StdResult<_> {
+            WHITELIST.save(deps.storage, asset, chain_id)?;
+            ASSET_REWARD_RATE.update(deps.storage, asset, |rate| -> StdResult<_> {
                 Ok(rate.unwrap_or(Decimal::zero()))
             })?;
         }
@@ -245,7 +245,7 @@ fn remove_assets(
     // Only allow the governance address to update whitelisted assets
     is_governance(&info, &config)?;
     for asset in &assets {
-        WHITELIST.remove(deps.storage, &asset);
+        WHITELIST.remove(deps.storage, asset);
     }
     let assets_str = assets
         .iter()

--- a/contracts/alliance-hub/src/error.rs
+++ b/contracts/alliance-hub/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{DecimalRangeExceeded, StdError};
+use cw_asset_v3::AssetError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -39,6 +40,9 @@ pub enum ContractError {
 
     #[error("Semver parsing error: {0}")]
     SemVer(String),
+
+    #[error("{0}")]
+    AssetError(#[from] AssetError),
 }
 
 impl From<semver::Error> for ContractError {

--- a/contracts/alliance-hub/src/lib.rs
+++ b/contracts/alliance-hub/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 pub mod error;
+mod migrations;
 pub mod query;
 pub mod state;
 #[cfg(test)]

--- a/contracts/alliance-hub/src/migrations.rs
+++ b/contracts/alliance-hub/src/migrations.rs
@@ -1,0 +1,247 @@
+use crate::error::ContractError;
+use crate::state::{
+    ASSET_REWARD_DISTRIBUTION, ASSET_REWARD_RATE, BALANCES, TOTAL_BALANCES, UNCLAIMED_REWARDS,
+    USER_ASSET_REWARD_RATE, WHITELIST,
+};
+use alliance_protocol::alliance_oracle_types::ChainId;
+use alliance_protocol::alliance_protocol::AssetDistribution;
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{
+    to_json_binary, Addr, Decimal, DepsMut, Env, Order, StdError, StdResult, Uint128,
+};
+use cw_storage_plus_016::{Item as Item016, Map as Map016};
+use cw_storage_plus_120::{Item, Map, PrimaryKey};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+pub(crate) fn migrate_maps(deps: DepsMut, env: Env) -> Result<(), ContractError> {
+    migrate_whitelist_map(&deps)?;
+    migrate_balances_map(&deps)?;
+    migrate_total_balances_map(&deps)?;
+    migrate_asset_reward_distribution(&deps)?;
+    migrate_asset_reward_rate(&deps)?;
+    migrate_user_asset_reward_rate(&deps)?;
+    migrate_unclaimed_rewards(&deps)?;
+
+    Ok(())
+}
+
+fn migrate_whitelist_map(deps: &DepsMut) -> Result<(), ContractError> {
+    const OLD_WHITELIST: Map016<cw_asset_v2::AssetInfoKey, ChainId> = Map016::new("whitelist");
+
+    let old_map = OLD_WHITELIST
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|item| {
+            let (key, value) = item.unwrap();
+            (key, value)
+        })
+        .collect::<Vec<_>>();
+
+    OLD_WHITELIST.clear(deps.storage);
+
+    for (key, value) in old_map {
+        let asset_info_v3 = match key {
+            cw_asset_v2::AssetInfoUnchecked::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfoUnchecked::Cw20(x) => {
+                cw_asset_v3::AssetInfo::cw20(deps.api.addr_validate(&x)?)
+            }
+            _ => panic!("unsupported"),
+        };
+        WHITELIST
+            .save(deps.storage, &asset_info_v3, &value)
+            .unwrap();
+    }
+
+    Ok(())
+}
+fn migrate_balances_map(deps: &DepsMut) -> Result<(), ContractError> {
+    const OLD_BALANCES: Map016<(Addr, cw_asset_v2::AssetInfoKey), Uint128> =
+        Map016::new("balances");
+
+    let old_map = OLD_BALANCES
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|item| {
+            let (key, value) = item.unwrap();
+            (key, value)
+        })
+        .collect::<Vec<_>>();
+
+    OLD_BALANCES.clear(deps.storage);
+
+    for (key, value) in old_map {
+        let asset_info_v3 = match key.1 {
+            cw_asset_v2::AssetInfoUnchecked::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfoUnchecked::Cw20(x) => {
+                cw_asset_v3::AssetInfo::cw20(deps.api.addr_validate(&x)?)
+            }
+            _ => panic!("unsupported"),
+        };
+
+        BALANCES
+            .save(deps.storage, (key.0, &asset_info_v3), &value)
+            .unwrap();
+    }
+
+    Ok(())
+}
+fn migrate_total_balances_map(deps: &DepsMut) -> Result<(), ContractError> {
+    const OLD_TOTAL_BALANCES: Map016<cw_asset_v2::AssetInfoKey, Uint128> =
+        Map016::new("total_balances");
+
+    let old_map = OLD_TOTAL_BALANCES
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|item| {
+            let (key, value) = item.unwrap();
+            (key, value)
+        })
+        .collect::<Vec<_>>();
+
+    OLD_TOTAL_BALANCES.clear(deps.storage);
+
+    for (key, value) in old_map {
+        let asset_info_v3 = match key {
+            cw_asset_v2::AssetInfoUnchecked::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfoUnchecked::Cw20(x) => {
+                cw_asset_v3::AssetInfo::cw20(deps.api.addr_validate(&x)?)
+            }
+            _ => panic!("unsupported"),
+        };
+
+        TOTAL_BALANCES
+            .save(deps.storage, &asset_info_v3, &value)
+            .unwrap();
+    }
+
+    Ok(())
+}
+
+fn migrate_asset_reward_distribution(deps: &DepsMut) -> Result<(), ContractError> {
+    #[cw_serde]
+    pub struct OldAssetDistribution {
+        pub asset: cw_asset_v2::AssetInfo,
+        pub distribution: Decimal,
+    }
+
+    const OLD_ASSET_REWARD_DISTRIBUTION: Item016<Vec<OldAssetDistribution>> =
+        Item016::new("asset_reward_distribution");
+    let old_asset_reward_distribution = OLD_ASSET_REWARD_DISTRIBUTION.load(deps.storage)?;
+
+    OLD_ASSET_REWARD_DISTRIBUTION.remove(deps.storage);
+
+    let mut asset_reward_distribution: Vec<AssetDistribution> = Vec::new();
+    for a in old_asset_reward_distribution {
+        let asset_info_v3 = match a.asset {
+            cw_asset_v2::AssetInfo::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfo::Cw20(x) => cw_asset_v3::AssetInfo::cw20(x),
+            _ => panic!("unsupported"),
+        };
+
+        asset_reward_distribution.push(AssetDistribution {
+            asset: asset_info_v3,
+            distribution: a.distribution,
+        });
+    }
+
+    ASSET_REWARD_DISTRIBUTION.save(deps.storage, &asset_reward_distribution)?;
+
+    Ok(())
+}
+
+fn migrate_asset_reward_rate(deps: &DepsMut) -> Result<(), ContractError> {
+    const OLD_ASSET_REWARD_RATE: Map016<cw_asset_v2::AssetInfoKey, Decimal> =
+        Map016::new("asset_reward_rate");
+
+    let old_map = OLD_ASSET_REWARD_RATE
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|item| {
+            let (key, value) = item.unwrap();
+            (key, value)
+        })
+        .collect::<Vec<_>>();
+
+    OLD_ASSET_REWARD_RATE.clear(deps.storage);
+
+    for (key, value) in old_map {
+        let asset_info_v3 = match key {
+            cw_asset_v2::AssetInfoUnchecked::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfoUnchecked::Cw20(x) => {
+                cw_asset_v3::AssetInfo::cw20(deps.api.addr_validate(&x)?)
+            }
+            _ => panic!("unsupported"),
+        };
+
+        ASSET_REWARD_RATE
+            .save(deps.storage, &asset_info_v3, &value)
+            .unwrap();
+    }
+
+    Ok(())
+}
+
+fn migrate_user_asset_reward_rate(deps: &DepsMut) -> Result<(), ContractError> {
+    const OLD_USER_ASSET_REWARD_RATE: Map016<(Addr, cw_asset_v2::AssetInfoKey), Decimal> =
+        Map016::new("user_asset_reward_rate");
+
+    let old_map = OLD_USER_ASSET_REWARD_RATE
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|item| {
+            let (key, value) = item.unwrap();
+            (key, value)
+        })
+        .collect::<Vec<_>>();
+
+    OLD_USER_ASSET_REWARD_RATE.clear(deps.storage);
+
+    for (key, value) in old_map {
+        let asset_info_v3 = match key.1 {
+            cw_asset_v2::AssetInfoUnchecked::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfoUnchecked::Cw20(x) => {
+                cw_asset_v3::AssetInfo::cw20(deps.api.addr_validate(&x)?)
+            }
+            _ => panic!("unsupported"),
+        };
+
+        USER_ASSET_REWARD_RATE
+            .save(deps.storage, (key.0, &asset_info_v3), &value)
+            .unwrap();
+    }
+
+    Ok(())
+}
+
+fn migrate_unclaimed_rewards(deps: &DepsMut) -> Result<(), ContractError> {
+    pub const OLD_UNCLAIMED_REWARDS: Map016<(Addr, cw_asset_v2::AssetInfoKey), Uint128> =
+        Map016::new("unclaimed_rewards");
+
+    let old_map = OLD_UNCLAIMED_REWARDS
+        .range(deps.storage, None, None, Order::Ascending)
+        .into_iter()
+        .map(|item| {
+            let (key, value) = item.unwrap();
+            (key, value)
+        })
+        .collect::<Vec<_>>();
+
+    OLD_UNCLAIMED_REWARDS.clear(deps.storage);
+
+    for (key, value) in old_map {
+        let asset_info_v3 = match key.1 {
+            cw_asset_v2::AssetInfoUnchecked::Native(x) => cw_asset_v3::AssetInfo::native(x),
+            cw_asset_v2::AssetInfoUnchecked::Cw20(x) => {
+                cw_asset_v3::AssetInfo::cw20(deps.api.addr_validate(&x)?)
+            }
+            _ => panic!("unsupported"),
+        };
+
+        UNCLAIMED_REWARDS
+            .save(deps.storage, (key.0, &asset_info_v3), &value)
+            .unwrap();
+    }
+
+    Ok(())
+}

--- a/contracts/alliance-hub/src/migrations.rs
+++ b/contracts/alliance-hub/src/migrations.rs
@@ -26,7 +26,6 @@ fn migrate_whitelist_map(deps: DepsMut) -> Result<(), ContractError> {
 
     let old_map = OLD_WHITELIST
         .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
         .map(|item| {
             let (key, value) = item.unwrap();
             (key, value)
@@ -56,7 +55,6 @@ fn migrate_balances_map(deps: DepsMut) -> Result<(), ContractError> {
 
     let old_map = OLD_BALANCES
         .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
         .map(|item| {
             let (key, value) = item.unwrap();
             (key, value)
@@ -87,7 +85,6 @@ fn migrate_total_balances_map(deps: DepsMut) -> Result<(), ContractError> {
 
     let old_map = OLD_TOTAL_BALANCES
         .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
         .map(|item| {
             let (key, value) = item.unwrap();
             (key, value)
@@ -151,7 +148,6 @@ fn migrate_asset_reward_rate(deps: DepsMut) -> Result<(), ContractError> {
 
     let old_map = OLD_ASSET_REWARD_RATE
         .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
         .map(|item| {
             let (key, value) = item.unwrap();
             (key, value)
@@ -183,7 +179,6 @@ fn migrate_user_asset_reward_rate(deps: DepsMut) -> Result<(), ContractError> {
 
     let old_map = OLD_USER_ASSET_REWARD_RATE
         .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
         .map(|item| {
             let (key, value) = item.unwrap();
             (key, value)
@@ -215,7 +210,6 @@ fn migrate_unclaimed_rewards(deps: DepsMut) -> Result<(), ContractError> {
 
     let old_map = OLD_UNCLAIMED_REWARDS
         .range(deps.storage, None, None, Order::Ascending)
-        .into_iter()
         .map(|item| {
             let (key, value) = item.unwrap();
             (key, value)

--- a/contracts/alliance-hub/src/migrations.rs
+++ b/contracts/alliance-hub/src/migrations.rs
@@ -6,27 +6,22 @@ use crate::state::{
 use alliance_protocol::alliance_oracle_types::ChainId;
 use alliance_protocol::alliance_protocol::AssetDistribution;
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{
-    to_json_binary, Addr, Decimal, DepsMut, Env, Order, StdError, StdResult, Uint128,
-};
+use cosmwasm_std::{Addr, Decimal, DepsMut, Order, Uint128};
 use cw_storage_plus_016::{Item as Item016, Map as Map016};
-use cw_storage_plus_120::{Item, Map, PrimaryKey};
-use serde::de::DeserializeOwned;
-use serde::Serialize;
 
-pub(crate) fn migrate_maps(deps: DepsMut, env: Env) -> Result<(), ContractError> {
-    migrate_whitelist_map(&deps)?;
-    migrate_balances_map(&deps)?;
-    migrate_total_balances_map(&deps)?;
-    migrate_asset_reward_distribution(&deps)?;
-    migrate_asset_reward_rate(&deps)?;
-    migrate_user_asset_reward_rate(&deps)?;
-    migrate_unclaimed_rewards(&deps)?;
+pub(crate) fn migrate_maps(mut deps: DepsMut) -> Result<(), ContractError> {
+    migrate_whitelist_map(deps.branch())?;
+    migrate_balances_map(deps.branch())?;
+    migrate_total_balances_map(deps.branch())?;
+    migrate_asset_reward_distribution(deps.branch())?;
+    migrate_asset_reward_rate(deps.branch())?;
+    migrate_user_asset_reward_rate(deps.branch())?;
+    migrate_unclaimed_rewards(deps.branch())?;
 
     Ok(())
 }
 
-fn migrate_whitelist_map(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_whitelist_map(deps: DepsMut) -> Result<(), ContractError> {
     const OLD_WHITELIST: Map016<cw_asset_v2::AssetInfoKey, ChainId> = Map016::new("whitelist");
 
     let old_map = OLD_WHITELIST
@@ -55,7 +50,7 @@ fn migrate_whitelist_map(deps: &DepsMut) -> Result<(), ContractError> {
 
     Ok(())
 }
-fn migrate_balances_map(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_balances_map(deps: DepsMut) -> Result<(), ContractError> {
     const OLD_BALANCES: Map016<(Addr, cw_asset_v2::AssetInfoKey), Uint128> =
         Map016::new("balances");
 
@@ -86,7 +81,7 @@ fn migrate_balances_map(deps: &DepsMut) -> Result<(), ContractError> {
 
     Ok(())
 }
-fn migrate_total_balances_map(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_total_balances_map(deps: DepsMut) -> Result<(), ContractError> {
     const OLD_TOTAL_BALANCES: Map016<cw_asset_v2::AssetInfoKey, Uint128> =
         Map016::new("total_balances");
 
@@ -118,7 +113,7 @@ fn migrate_total_balances_map(deps: &DepsMut) -> Result<(), ContractError> {
     Ok(())
 }
 
-fn migrate_asset_reward_distribution(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_asset_reward_distribution(deps: DepsMut) -> Result<(), ContractError> {
     #[cw_serde]
     pub struct OldAssetDistribution {
         pub asset: cw_asset_v2::AssetInfo,
@@ -150,7 +145,7 @@ fn migrate_asset_reward_distribution(deps: &DepsMut) -> Result<(), ContractError
     Ok(())
 }
 
-fn migrate_asset_reward_rate(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_asset_reward_rate(deps: DepsMut) -> Result<(), ContractError> {
     const OLD_ASSET_REWARD_RATE: Map016<cw_asset_v2::AssetInfoKey, Decimal> =
         Map016::new("asset_reward_rate");
 
@@ -182,7 +177,7 @@ fn migrate_asset_reward_rate(deps: &DepsMut) -> Result<(), ContractError> {
     Ok(())
 }
 
-fn migrate_user_asset_reward_rate(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_user_asset_reward_rate(deps: DepsMut) -> Result<(), ContractError> {
     const OLD_USER_ASSET_REWARD_RATE: Map016<(Addr, cw_asset_v2::AssetInfoKey), Decimal> =
         Map016::new("user_asset_reward_rate");
 
@@ -214,7 +209,7 @@ fn migrate_user_asset_reward_rate(deps: &DepsMut) -> Result<(), ContractError> {
     Ok(())
 }
 
-fn migrate_unclaimed_rewards(deps: &DepsMut) -> Result<(), ContractError> {
+fn migrate_unclaimed_rewards(deps: DepsMut) -> Result<(), ContractError> {
     pub const OLD_UNCLAIMED_REWARDS: Map016<(Addr, cw_asset_v2::AssetInfoKey), Uint128> =
         Map016::new("unclaimed_rewards");
 

--- a/contracts/alliance-hub/src/query.rs
+++ b/contracts/alliance-hub/src/query.rs
@@ -5,7 +5,7 @@ use alliance_protocol::alliance_protocol::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{to_binary, Binary, Deps, Env, Order, StdResult, Uint128};
-use cw_asset::{AssetInfo, AssetInfoKey};
+use cw_asset_v2::{AssetInfo, AssetInfoKey};
 use std::collections::HashMap;
 
 use crate::state::{

--- a/contracts/alliance-hub/src/query.rs
+++ b/contracts/alliance-hub/src/query.rs
@@ -4,8 +4,8 @@ use alliance_protocol::alliance_protocol::{
 };
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{to_binary, Binary, Deps, Env, Order, StdResult, Uint128};
-use cw_asset_v2::{AssetInfo, AssetInfoKey};
+use cosmwasm_std::{to_json_binary, Binary, Deps, Env, Order, StdResult, Uint128};
+use cw_asset_v3::AssetInfo;
 use std::collections::HashMap;
 
 use crate::state::{
@@ -31,13 +31,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 fn get_config(deps: Deps) -> StdResult<Binary> {
     let cfg = CONFIG.load(deps.storage)?;
 
-    to_binary(&cfg)
+    to_json_binary(&cfg)
 }
 
 fn get_validators(deps: Deps) -> StdResult<Binary> {
     let validators = VALIDATORS.load(deps.storage)?;
 
-    to_binary(&validators)
+    to_json_binary(&validators)
 }
 
 fn get_whitelisted_assets(deps: Deps) -> StdResult<Binary> {
@@ -45,27 +45,26 @@ fn get_whitelisted_assets(deps: Deps) -> StdResult<Binary> {
     let mut res: WhitelistedAssetsResponse = HashMap::new();
 
     for item in whitelist {
-        let (key, chain_id) = item?;
-        let asset = key.check(deps.api, None)?;
+        let (asset, chain_id) = item?;
         #[allow(clippy::unwrap_or_default)]
         res.entry(chain_id).or_insert_with(Vec::new).push(asset)
     }
 
-    to_binary(&res)
+    to_json_binary(&res)
 }
 
 fn get_rewards_distribution(deps: Deps) -> StdResult<Binary> {
     let asset_rewards_distr = ASSET_REWARD_DISTRIBUTION.load(deps.storage)?;
 
-    to_binary(&asset_rewards_distr)
+    to_json_binary(&asset_rewards_distr)
 }
 
 fn get_staked_balance(deps: Deps, asset_query: AssetQuery) -> StdResult<Binary> {
     let addr = deps.api.addr_validate(&asset_query.address)?;
-    let key = (addr, asset_query.asset.clone().into());
+    let key = (addr, &asset_query.asset);
     let balance = BALANCES.load(deps.storage, key)?;
 
-    to_binary(&StakedBalanceRes {
+    to_json_binary(&StakedBalanceRes {
         asset: asset_query.asset,
         balance,
     })
@@ -74,17 +73,16 @@ fn get_staked_balance(deps: Deps, asset_query: AssetQuery) -> StdResult<Binary> 
 fn get_pending_rewards(deps: Deps, asset_query: AssetQuery) -> StdResult<Binary> {
     let config = CONFIG.load(deps.storage)?;
     let addr = deps.api.addr_validate(&asset_query.address)?;
-    let key = (addr, AssetInfoKey::from(asset_query.asset.clone()));
+    let key = (addr, &asset_query.asset.clone());
     let user_reward_rate = USER_ASSET_REWARD_RATE.load(deps.storage, key.clone())?;
-    let asset_reward_rate =
-        ASSET_REWARD_RATE.load(deps.storage, AssetInfoKey::from(asset_query.asset.clone()))?;
+    let asset_reward_rate = ASSET_REWARD_RATE.load(deps.storage, &asset_query.asset.clone())?;
     let user_balance = BALANCES.load(deps.storage, key.clone())?;
     let unclaimed_rewards = UNCLAIMED_REWARDS
         .load(deps.storage, key)
         .unwrap_or(Uint128::zero());
     let pending_rewards = (asset_reward_rate - user_reward_rate) * user_balance;
 
-    to_binary(&PendingRewardsRes {
+    to_json_binary(&PendingRewardsRes {
         rewards: unclaimed_rewards + pending_rewards,
         staked_asset: asset_query.asset,
         reward_asset: AssetInfo::Native(config.reward_denom),
@@ -98,22 +96,20 @@ fn get_all_staked_balances(deps: Deps, asset_query: AllStakedBalancesQuery) -> S
 
     for asset_res in whitelist {
         // Build the required key to recover the BALANCES
-        let (asset_key, _) = asset_res?;
-        let checked_asset_info = asset_key.check(deps.api, None)?;
-        let asset_info_key = AssetInfoKey::from(checked_asset_info.clone());
-        let stake_key = (addr.clone(), asset_info_key);
+        let (asset_info, _) = asset_res?;
+        let stake_key = (addr.clone(), &asset_info);
         let balance = BALANCES
             .load(deps.storage, stake_key)
             .unwrap_or(Uint128::zero());
 
         // Append the request
         res.push(StakedBalanceRes {
-            asset: checked_asset_info,
+            asset: asset_info.clone(),
             balance,
         })
     }
 
-    to_binary(&res)
+    to_json_binary(&res)
 }
 
 fn get_all_pending_rewards(deps: Deps, query: AllPendingRewardsQuery) -> StdResult<Binary> {
@@ -123,30 +119,22 @@ fn get_all_pending_rewards(deps: Deps, query: AllPendingRewardsQuery) -> StdResu
         .prefix(addr.clone())
         .range(deps.storage, None, None, Order::Ascending)
         .map(|item| {
-            let (asset, user_reward_rate) = item?;
-            let asset = asset.check(deps.api, None)?;
-            let asset_reward_rate =
-                ASSET_REWARD_RATE.load(deps.storage, AssetInfoKey::from(asset.clone()))?;
-            let user_balance = BALANCES.load(
-                deps.storage,
-                (addr.clone(), AssetInfoKey::from(asset.clone())),
-            )?;
+            let (asset_info, user_reward_rate) = item?;
+            let asset_reward_rate = ASSET_REWARD_RATE.load(deps.storage, &asset_info)?;
+            let user_balance = BALANCES.load(deps.storage, (addr.clone(), &asset_info))?;
             let unclaimed_rewards = UNCLAIMED_REWARDS
-                .load(
-                    deps.storage,
-                    (addr.clone(), AssetInfoKey::from(asset.clone())),
-                )
+                .load(deps.storage, (addr.clone(), &asset_info))
                 .unwrap_or(Uint128::zero());
             let pending_rewards = (asset_reward_rate - user_reward_rate) * user_balance;
             Ok(PendingRewardsRes {
                 rewards: pending_rewards + unclaimed_rewards,
-                staked_asset: asset,
+                staked_asset: asset_info.clone(),
                 reward_asset: AssetInfo::Native(config.reward_denom.to_string()),
             })
         })
         .collect::<StdResult<Vec<PendingRewardsRes>>>();
 
-    to_binary(&all_pending_rewards?)
+    to_json_binary(&all_pending_rewards?)
 }
 
 fn get_total_staked_balances(deps: Deps) -> StdResult<Binary> {
@@ -154,11 +142,8 @@ fn get_total_staked_balances(deps: Deps) -> StdResult<Binary> {
         .range(deps.storage, None, None, Order::Ascending)
         .map(|total_balance| -> StdResult<StakedBalanceRes> {
             let (asset, balance) = total_balance?;
-            Ok(StakedBalanceRes {
-                asset: asset.check(deps.api, None)?,
-                balance,
-            })
+            Ok(StakedBalanceRes { asset, balance })
         })
         .collect();
-    to_binary(&total_staked_balances?)
+    to_json_binary(&total_staked_balances?)
 }

--- a/contracts/alliance-hub/src/state.rs
+++ b/contracts/alliance-hub/src/state.rs
@@ -1,7 +1,6 @@
 use alliance_protocol::alliance_oracle_types::ChainId;
 use alliance_protocol::alliance_protocol::{AssetDistribution, Config};
 use cosmwasm_std::{Addr, Decimal, Uint128};
-use cw_asset_v2::AssetInfoKey;
 use cw_asset_v3::AssetInfo;
 use cw_storage_plus_120::{Item, Map};
 use std::collections::HashSet;

--- a/contracts/alliance-hub/src/state.rs
+++ b/contracts/alliance-hub/src/state.rs
@@ -1,23 +1,23 @@
 use alliance_protocol::alliance_oracle_types::ChainId;
 use alliance_protocol::alliance_protocol::{AssetDistribution, Config};
 use cosmwasm_std::{Addr, Decimal, Uint128};
-use cw_asset::AssetInfoKey;
-use cw_storage_plus::{Item, Map};
+use cw_asset_v2::AssetInfoKey;
+use cw_asset_v3::AssetInfo;
+use cw_storage_plus_120::{Item, Map};
 use std::collections::HashSet;
 
 pub const CONFIG: Item<Config> = Item::new("config");
-pub const WHITELIST: Map<AssetInfoKey, ChainId> = Map::new("whitelist");
-
-pub const BALANCES: Map<(Addr, AssetInfoKey), Uint128> = Map::new("balances");
-pub const TOTAL_BALANCES: Map<AssetInfoKey, Uint128> = Map::new("total_balances");
+pub const WHITELIST: Map<&AssetInfo, ChainId> = Map::new("whitelist");
+pub const BALANCES: Map<(Addr, &AssetInfo), Uint128> = Map::new("balances");
+pub const TOTAL_BALANCES: Map<&AssetInfo, Uint128> = Map::new("total_balances");
 
 pub const VALIDATORS: Item<HashSet<String>> = Item::new("validators");
 
 pub const ASSET_REWARD_DISTRIBUTION: Item<Vec<AssetDistribution>> =
     Item::new("asset_reward_distribution");
-pub const ASSET_REWARD_RATE: Map<AssetInfoKey, Decimal> = Map::new("asset_reward_rate");
-pub const USER_ASSET_REWARD_RATE: Map<(Addr, AssetInfoKey), Decimal> =
+pub const ASSET_REWARD_RATE: Map<&AssetInfo, Decimal> = Map::new("asset_reward_rate");
+pub const USER_ASSET_REWARD_RATE: Map<(Addr, &AssetInfo), Decimal> =
     Map::new("user_asset_reward_rate");
-pub const UNCLAIMED_REWARDS: Map<(Addr, AssetInfoKey), Uint128> = Map::new("unclaimed_rewards");
+pub const UNCLAIMED_REWARDS: Map<(Addr, &AssetInfo), Uint128> = Map::new("unclaimed_rewards");
 
 pub const TEMP_BALANCE: Item<Uint128> = Item::new("temp_balance");

--- a/contracts/alliance-hub/src/tests/assets.rs
+++ b/contracts/alliance-hub/src/tests/assets.rs
@@ -6,7 +6,7 @@ use crate::tests::helpers::{remove_assets, setup_contract, whitelist_assets};
 use alliance_protocol::alliance_protocol::{ExecuteMsg, QueryMsg, WhitelistedAssetsResponse};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{from_binary, Response};
-use cw_asset::{AssetInfo, AssetInfoKey};
+use cw_asset_v2::{AssetInfo, AssetInfoKey};
 use std::collections::HashMap;
 
 #[test]

--- a/contracts/alliance-hub/src/tests/assets.rs
+++ b/contracts/alliance-hub/src/tests/assets.rs
@@ -5,8 +5,8 @@ use crate::state::WHITELIST;
 use crate::tests::helpers::{remove_assets, setup_contract, whitelist_assets};
 use alliance_protocol::alliance_protocol::{ExecuteMsg, QueryMsg, WhitelistedAssetsResponse};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{from_binary, Response};
-use cw_asset_v2::{AssetInfo, AssetInfoKey};
+use cosmwasm_std::{from_json, Response};
+use cw_asset_v3::AssetInfo;
 use std::collections::HashMap;
 
 #[test]
@@ -51,13 +51,13 @@ fn test_whitelist_assets() {
     let chain_id = WHITELIST
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("asset2".to_string())),
+            &AssetInfo::Native("asset2".to_string()),
         )
         .unwrap();
     assert_eq!(chain_id, "chain-1".to_string());
 
     let res: WhitelistedAssetsResponse =
-        from_binary(&query(deps.as_ref(), mock_env(), QueryMsg::WhitelistedAssets {}).unwrap())
+        from_json(&query(deps.as_ref(), mock_env(), QueryMsg::WhitelistedAssets {}).unwrap())
             .unwrap();
     assert_eq!(
         res,
@@ -116,7 +116,7 @@ fn test_remove_assets() {
     WHITELIST
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+            &AssetInfo::Native("asset1".to_string()),
         )
         .unwrap_err();
 }

--- a/contracts/alliance-hub/src/tests/helpers.rs
+++ b/contracts/alliance-hub/src/tests/helpers.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     coin, from_binary, to_binary, Decimal, Deps, DepsMut, Response, StdResult, Uint128,
 };
 use cw20::Cw20ReceiveMsg;
-use cw_asset::{Asset, AssetInfo};
+use cw_asset_v2::{Asset, AssetInfo};
 
 use alliance_protocol::alliance_oracle_types::ChainId;
 use alliance_protocol::alliance_protocol::{

--- a/contracts/alliance-hub/src/tests/helpers.rs
+++ b/contracts/alliance-hub/src/tests/helpers.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{
-    coin, from_binary, to_binary, Decimal, Deps, DepsMut, Response, StdResult, Uint128,
+    coin, from_json, to_json_binary, Decimal, Deps, DepsMut, Response, StdResult, Uint128,
 };
 use cw20::Cw20ReceiveMsg;
-use cw_asset_v2::{Asset, AssetInfo};
+use cw_asset_v3::{Asset, AssetInfo};
 
 use alliance_protocol::alliance_oracle_types::ChainId;
 use alliance_protocol::alliance_protocol::{
@@ -77,7 +77,7 @@ pub fn stake_cw20(deps: DepsMut, user: &str, amount: u128, denom: &str) -> Respo
     let msg = ExecuteMsg::Receive(Cw20ReceiveMsg {
         sender: user.to_string(),
         amount: amount.into(),
-        msg: to_binary(&Cw20HookMsg::Stake {}).unwrap(),
+        msg: to_json_binary(&Cw20HookMsg::Stake {}).unwrap(),
     });
     execute(deps, env, info, msg).unwrap()
 }
@@ -149,7 +149,7 @@ pub fn claim_rewards(deps: DepsMut, user: &str, denom: &str) -> Response {
 }
 
 pub fn query_rewards(deps: Deps, user: &str, denom: &str) -> PendingRewardsRes {
-    from_binary(
+    from_json(
         &query(
             deps,
             mock_env(),
@@ -164,7 +164,7 @@ pub fn query_rewards(deps: Deps, user: &str, denom: &str) -> PendingRewardsRes {
 }
 
 pub fn query_all_rewards(deps: Deps, user: &str) -> Vec<PendingRewardsRes> {
-    from_binary(
+    from_json(
         &query(
             deps,
             mock_env(),
@@ -178,11 +178,11 @@ pub fn query_all_rewards(deps: Deps, user: &str) -> Vec<PendingRewardsRes> {
 }
 
 pub fn query_all_staked_balances(deps: Deps) -> Vec<StakedBalanceRes> {
-    from_binary(&query(deps, mock_env(), QueryMsg::TotalStakedBalances {}).unwrap()).unwrap()
+    from_json(&query(deps, mock_env(), QueryMsg::TotalStakedBalances {}).unwrap()).unwrap()
 }
 
 pub fn query_asset_reward_distribution(deps: Deps) -> Vec<AssetDistribution> {
-    from_binary(&query(deps, mock_env(), QueryMsg::RewardDistribution {}).unwrap()).unwrap()
+    from_json(&query(deps, mock_env(), QueryMsg::RewardDistribution {}).unwrap()).unwrap()
 }
 
 #[inline]

--- a/contracts/alliance-hub/src/tests/instantiate.rs
+++ b/contracts/alliance-hub/src/tests/instantiate.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{
-    from_binary, Addr, Binary, CosmosMsg, Reply, Response, SubMsg, SubMsgResponse, SubMsgResult,
+    from_json, Addr, Binary, CosmosMsg, Reply, Response, SubMsg, SubMsgResponse, SubMsgResult,
     Timestamp, Uint128,
 };
 use terra_proto_rs::traits::MessageExt;
@@ -34,7 +34,7 @@ fn test_setup_contract() {
     // alliance_token_denom and alliance_token_supply
     // will be populated on reply.
     let query_config = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
-    let config: Config = from_binary(&query_config).unwrap();
+    let config: Config = from_json(&query_config).unwrap();
     assert_eq!(
         config,
         Config {
@@ -104,7 +104,7 @@ fn test_reply_create_token() {
     );
 
     let query_config = query(deps.as_ref(), mock_env(), QueryMsg::Config {}).unwrap();
-    let config: Config = from_binary(&query_config).unwrap();
+    let config: Config = from_json(&query_config).unwrap();
     assert_eq!(
         config,
         Config {
@@ -132,7 +132,7 @@ fn test_update_config() {
         oracle,
         operator,
         ..
-    } = from_binary(&query_config).unwrap();
+    } = from_json(&query_config).unwrap();
 
     assert_eq!(governance, Addr::unchecked("gov"));
     assert_eq!(controller, Addr::unchecked("controller"));
@@ -192,7 +192,7 @@ fn test_update_config() {
         oracle,
         operator,
         ..
-    } = from_binary(&query_config).unwrap();
+    } = from_json(&query_config).unwrap();
 
     assert_eq!(governance, Addr::unchecked("new_gov"));
     assert_eq!(controller, Addr::unchecked("new_controller"));

--- a/contracts/alliance-hub/src/tests/rewards.rs
+++ b/contracts/alliance-hub/src/tests/rewards.rs
@@ -2,10 +2,10 @@ use std::collections::{HashMap, HashSet};
 
 use cosmwasm_std::testing::{mock_dependencies_with_balance, mock_env, mock_info};
 use cosmwasm_std::{
-    coin, coins, to_binary, Addr, BankMsg, Binary, CosmosMsg, Decimal, Response, SubMsg, Uint128,
-    WasmMsg,
+    coin, coins, to_json_binary, Addr, BankMsg, Binary, CosmosMsg, Decimal, Response, SubMsg,
+    Uint128, WasmMsg,
 };
-use cw_asset_v2::{AssetInfo, AssetInfoKey};
+use cw_asset_v3::AssetInfo;
 use terra_proto_rs::alliance::alliance::MsgClaimDelegationRewards;
 use terra_proto_rs::traits::Message;
 
@@ -63,7 +63,7 @@ fn test_update_rewards() {
             SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
                 funds: vec![],
                 contract_addr: "cosmos2contract".to_string(),
-                msg: to_binary(&ExecuteMsg::UpdateRewardsCallback {}).unwrap(),
+                msg: to_json_binary(&ExecuteMsg::UpdateRewardsCallback {}).unwrap(),
             })),
         ]
     );
@@ -107,14 +107,14 @@ fn update_reward_callback() {
     TOTAL_BALANCES
         .save(
             deps.as_mut().storage,
-            AssetInfoKey::from(AssetInfo::Native("aWHALE".to_string())),
+            &AssetInfo::Native("aWHALE".to_string()),
             &Uint128::new(1000000),
         )
         .unwrap();
     TOTAL_BALANCES
         .save(
             deps.as_mut().storage,
-            AssetInfoKey::from(AssetInfo::Native("bWHALE".to_string())),
+            &AssetInfo::Native("bWHALE".to_string()),
             &Uint128::new(100000),
         )
         .unwrap();
@@ -153,7 +153,7 @@ fn update_reward_callback() {
     let a_whale_rate = ASSET_REWARD_RATE
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("aWHALE".to_string())),
+            &AssetInfo::Native("aWHALE".to_string()),
         )
         .unwrap();
     assert_eq!(
@@ -163,7 +163,7 @@ fn update_reward_callback() {
     let b_whale_rate = ASSET_REWARD_RATE
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("bWHALE".to_string())),
+            &AssetInfo::Native("bWHALE".to_string()),
         )
         .unwrap();
     assert_eq!(
@@ -173,7 +173,7 @@ fn update_reward_callback() {
     ASSET_REWARD_RATE
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("cMONKEY".to_string())),
+            &AssetInfo::Native("cMONKEY".to_string()),
         )
         .unwrap_err();
 
@@ -265,14 +265,14 @@ fn claim_user_rewards() {
             deps.as_ref().storage,
             (
                 Addr::unchecked("user1"),
-                AssetInfoKey::from(AssetInfo::Native("aWHALE".to_string())),
+                &AssetInfo::Native("aWHALE".to_string()),
             ),
         )
         .unwrap();
     let asset_reward_rate = ASSET_REWARD_RATE
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("aWHALE".to_string())),
+            &AssetInfo::Native("aWHALE".to_string()),
         )
         .unwrap();
     assert_eq!(user_reward_rate, asset_reward_rate);
@@ -460,7 +460,7 @@ fn claim_rewards_after_staking_and_unstaking() {
     let prev_rate = ASSET_REWARD_RATE
         .load(
             deps.as_mut().storage,
-            AssetInfoKey::from(AssetInfo::Native("aWHALE".to_string())),
+            &AssetInfo::Native("aWHALE".to_string()),
         )
         .unwrap();
 
@@ -482,7 +482,7 @@ fn claim_rewards_after_staking_and_unstaking() {
     let curr_rate = ASSET_REWARD_RATE
         .load(
             deps.as_mut().storage,
-            AssetInfoKey::from(AssetInfo::Native("aWHALE".to_string())),
+            &AssetInfo::Native("aWHALE".to_string()),
         )
         .unwrap();
     assert!(curr_rate > prev_rate);

--- a/contracts/alliance-hub/src/tests/rewards.rs
+++ b/contracts/alliance-hub/src/tests/rewards.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     coin, coins, to_binary, Addr, BankMsg, Binary, CosmosMsg, Decimal, Response, SubMsg, Uint128,
     WasmMsg,
 };
-use cw_asset::{AssetInfo, AssetInfoKey};
+use cw_asset_v2::{AssetInfo, AssetInfoKey};
 use terra_proto_rs::alliance::alliance::MsgClaimDelegationRewards;
 use terra_proto_rs::traits::Message;
 

--- a/contracts/alliance-hub/src/tests/stake_unstake.rs
+++ b/contracts/alliance-hub/src/tests/stake_unstake.rs
@@ -7,8 +7,8 @@ use crate::tests::helpers::{
 };
 use alliance_protocol::alliance_protocol::{ExecuteMsg, StakedBalanceRes};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{coin, to_binary, Addr, BankMsg, CosmosMsg, Response, Uint128, WasmMsg};
-use cw_asset_v2::{Asset, AssetInfo, AssetInfoKey};
+use cosmwasm_std::{coin, to_json_binary, Addr, BankMsg, CosmosMsg, Response, Uint128, WasmMsg};
+use cw_asset_v3::{Asset, AssetInfo};
 use std::collections::HashMap;
 
 mod cw20_support {
@@ -42,7 +42,7 @@ mod cw20_support {
                 deps.as_ref().storage,
                 (
                     Addr::unchecked("user1"),
-                    AssetInfoKey::from(AssetInfo::Cw20(Addr::unchecked("asset1"))),
+                    &AssetInfo::Cw20(Addr::unchecked("asset1")),
                 ),
             )
             .unwrap();
@@ -64,7 +64,7 @@ mod cw20_support {
                 deps.as_ref().storage,
                 (
                     Addr::unchecked("user1"),
-                    AssetInfoKey::from(AssetInfo::Cw20(Addr::unchecked("asset1"))),
+                    &AssetInfo::Cw20(Addr::unchecked("asset1")),
                 ),
             )
             .unwrap();
@@ -73,7 +73,7 @@ mod cw20_support {
         let total_balance = TOTAL_BALANCES
             .load(
                 deps.as_ref().storage,
-                AssetInfoKey::from(AssetInfo::Cw20(Addr::unchecked("asset1"))),
+                &AssetInfo::Cw20(Addr::unchecked("asset1")),
             )
             .unwrap();
         assert_eq!(total_balance, Uint128::new(200));
@@ -123,7 +123,7 @@ mod cw20_support {
                 ])
                 .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: "asset1".into(),
-                    msg: to_binary(&cw20::Cw20ExecuteMsg::Transfer {
+                    msg: to_json_binary(&cw20::Cw20ExecuteMsg::Transfer {
                         recipient: "user1".into(),
                         amount: Uint128::new(50),
                     })
@@ -137,7 +137,7 @@ mod cw20_support {
                 deps.as_ref().storage,
                 (
                     Addr::unchecked("user1"),
-                    AssetInfoKey::from(AssetInfo::Cw20(Addr::unchecked("asset1".to_string()))),
+                    &AssetInfo::Cw20(Addr::unchecked("asset1")),
                 ),
             )
             .unwrap();
@@ -155,7 +155,7 @@ mod cw20_support {
                 ])
                 .add_message(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: "asset1".into(),
-                    msg: to_binary(&cw20::Cw20ExecuteMsg::Transfer {
+                    msg: to_json_binary(&cw20::Cw20ExecuteMsg::Transfer {
                         recipient: "user1".into(),
                         amount: Uint128::new(50),
                     })
@@ -169,7 +169,7 @@ mod cw20_support {
                 deps.as_ref().storage,
                 (
                     Addr::unchecked("user1"),
-                    AssetInfoKey::from(AssetInfo::Cw20(Addr::unchecked("asset1".to_string()))),
+                    &AssetInfo::Cw20(Addr::unchecked("asset1")),
                 ),
             )
             .unwrap();
@@ -178,7 +178,7 @@ mod cw20_support {
         let total_balance = TOTAL_BALANCES
             .load(
                 deps.as_ref().storage,
-                AssetInfoKey::from(AssetInfo::Cw20(Addr::unchecked("asset1".to_string()))),
+                &AssetInfo::Cw20(Addr::unchecked("asset1")),
             )
             .unwrap();
         assert_eq!(total_balance, Uint128::new(0));
@@ -212,7 +212,7 @@ fn test_stake() {
             deps.as_ref().storage,
             (
                 Addr::unchecked("user1"),
-                AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+                &AssetInfo::Native("asset1".to_string()),
             ),
         )
         .unwrap();
@@ -234,7 +234,7 @@ fn test_stake() {
             deps.as_ref().storage,
             (
                 Addr::unchecked("user1"),
-                AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+                &AssetInfo::Native("asset1".to_string()),
             ),
         )
         .unwrap();
@@ -243,7 +243,7 @@ fn test_stake() {
     let total_balance = TOTAL_BALANCES
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+            &AssetInfo::Native("asset1".to_string()),
         )
         .unwrap();
     assert_eq!(total_balance, Uint128::new(200));
@@ -329,7 +329,7 @@ fn test_unstake() {
             deps.as_ref().storage,
             (
                 Addr::unchecked("user1"),
-                AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+                &AssetInfo::Native("asset1".to_string()),
             ),
         )
         .unwrap();
@@ -356,7 +356,7 @@ fn test_unstake() {
             deps.as_ref().storage,
             (
                 Addr::unchecked("user1"),
-                AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+                &AssetInfo::Native("asset1".to_string()),
             ),
         )
         .unwrap();
@@ -365,7 +365,7 @@ fn test_unstake() {
     let total_balance = TOTAL_BALANCES
         .load(
             deps.as_ref().storage,
-            AssetInfoKey::from(AssetInfo::Native("asset1".to_string())),
+            &AssetInfo::Native("asset1".to_string()),
         )
         .unwrap();
     assert_eq!(total_balance, Uint128::new(0));

--- a/contracts/alliance-hub/src/tests/stake_unstake.rs
+++ b/contracts/alliance-hub/src/tests/stake_unstake.rs
@@ -8,7 +8,7 @@ use crate::tests::helpers::{
 use alliance_protocol::alliance_protocol::{ExecuteMsg, StakedBalanceRes};
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::{coin, to_binary, Addr, BankMsg, CosmosMsg, Response, Uint128, WasmMsg};
-use cw_asset::{Asset, AssetInfo, AssetInfoKey};
+use cw_asset_v2::{Asset, AssetInfo, AssetInfoKey};
 use std::collections::HashMap;
 
 mod cw20_support {

--- a/contracts/alliance-oracle/Cargo.toml
+++ b/contracts/alliance-oracle/Cargo.toml
@@ -20,8 +20,8 @@ library = []
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cw-storage-plus = { workspace = true }
-cw-asset = { workspace = true }
+cw_storage_plus_016 = { workspace = true }
+cw_asset_v2 = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/contracts/alliance-oracle/src/contract.rs
+++ b/contracts/alliance-oracle/src/contract.rs
@@ -9,7 +9,7 @@ use alliance_protocol::signed_decimal::{Sign, SignedDecimal};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+    to_json_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
 };
 use cw2::set_contract_version;
 
@@ -104,7 +104,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 pub fn get_config(deps: Deps) -> StdResult<Binary> {
     let cfg = CONFIG.load(deps.storage)?;
 
-    to_binary(&cfg)
+    to_json_binary(&cfg)
 }
 
 pub fn get_luna_info(deps: Deps, env: Env) -> StdResult<Binary> {
@@ -113,7 +113,7 @@ pub fn get_luna_info(deps: Deps, env: Env) -> StdResult<Binary> {
 
     luna_info.is_expired(cfg.data_expiry_seconds, env.block.time)?;
 
-    to_binary(&luna_info)
+    to_json_binary(&luna_info)
 }
 
 pub fn get_chain_info(deps: Deps, env: Env, chain_id: ChainId) -> StdResult<Binary> {
@@ -123,7 +123,7 @@ pub fn get_chain_info(deps: Deps, env: Env, chain_id: ChainId) -> StdResult<Bina
     for chain_info in &chains_info {
         if chain_info.chain_id == chain_id {
             chain_info.is_expired(cfg.data_expiry_seconds, env.block.time)?;
-            return to_binary(&chain_info);
+            return to_json_binary(&chain_info);
         }
     }
 
@@ -139,12 +139,12 @@ pub fn get_chains_info(deps: Deps, env: Env) -> StdResult<Binary> {
         chain_info.is_expired(cfg.data_expiry_seconds, env.block.time)?;
     }
 
-    to_binary(&chains_info)
+    to_json_binary(&chains_info)
 }
 
 pub fn get_chains_info_unsafe(deps: Deps) -> StdResult<Binary> {
     let chains_info = CHAINS_INFO.load(deps.storage)?;
-    to_binary(&chains_info)
+    to_json_binary(&chains_info)
 }
 
 pub fn get_emissions_distribution_info(
@@ -237,5 +237,5 @@ pub fn get_emissions_distribution_info(
         }
     }
 
-    to_binary(&emission_distribution)
+    to_json_binary(&emission_distribution)
 }

--- a/contracts/alliance-oracle/src/state.rs
+++ b/contracts/alliance-oracle/src/state.rs
@@ -1,5 +1,5 @@
 use alliance_protocol::alliance_oracle_types::{ChainInfo, Config, LunaInfo};
-use cw_storage_plus::Item;
+use cw_storage_plus_016::Item;
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const CHAINS_INFO: Item<Vec<ChainInfo>> = Item::new("chains_info");

--- a/contracts/alliance-oracle/src/tests/mod.rs
+++ b/contracts/alliance-oracle/src/tests/mod.rs
@@ -6,7 +6,7 @@ use alliance_protocol::alliance_oracle_types::{
 };
 use alliance_protocol::signed_decimal::SignedDecimal;
 use cosmwasm_std::{
-    from_binary,
+    from_json,
     testing::{mock_env, mock_info},
     Decimal, Uint128,
 };
@@ -57,7 +57,7 @@ fn test_update_oracle_data() {
 
     // Query the chains info to validate the data was stored correctly in the contract
     let res = query(deps.as_ref(), mock_env(), QueryMsg::QueryChainsInfo {}).unwrap();
-    let res: Vec<ChainInfo> = from_binary(&res).unwrap();
+    let res: Vec<ChainInfo> = from_json(&res).unwrap();
     assert_eq!(1, res.len());
 
     let chain_info = res[0].clone();
@@ -94,7 +94,7 @@ fn test_update_oracle_data() {
 
     // Query the Luna info to validate the data was stored correctly in the contract
     let res = query(deps.as_ref(), mock_env(), QueryMsg::QueryLunaInfo {}).unwrap();
-    let luna_info: LunaInfo = from_binary(&res).unwrap();
+    let luna_info: LunaInfo = from_json(&res).unwrap();
     assert_eq!(
         Decimal::from_str("0.589013565473308100").unwrap(),
         luna_info.luna_price
@@ -109,7 +109,7 @@ fn test_update_oracle_data() {
         },
     )
     .unwrap();
-    let chain_info: ChainInfo = from_binary(&res).unwrap();
+    let chain_info: ChainInfo = from_json(&res).unwrap();
     assert_eq!("chain-1", chain_info.chain_id);
     assert_eq!(
         NativeToken {
@@ -184,7 +184,7 @@ fn test_emissions_distribution() {
     )]));
 
     let res = query(deps.as_ref(), mock_env(), msg).unwrap();
-    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_json(&res).unwrap();
     assert_eq!(
         res_parsed,
         vec![EmissionsDistribution {
@@ -278,7 +278,7 @@ fn test_emissions_distribution_2() {
     ]));
 
     let res = query(deps.as_ref(), mock_env(), msg).unwrap();
-    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_json(&res).unwrap();
     assert_eq!(
         res_parsed,
         vec![
@@ -378,7 +378,7 @@ fn test_emissions_distribution_3() {
     ]));
 
     let res = query(deps.as_ref(), mock_env(), msg).unwrap();
-    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_json(&res).unwrap();
     assert_eq!(
         res_parsed,
         vec![
@@ -495,7 +495,7 @@ fn test_emissions_distribution_4() {
     ]));
 
     let res = query(deps.as_ref(), mock_env(), msg).unwrap();
-    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_json(&res).unwrap();
     assert_eq!(
         res_parsed,
         vec![
@@ -610,7 +610,7 @@ fn test_emissions_distribution_5() {
     ]));
 
     let res = query(deps.as_ref(), mock_env(), msg).unwrap();
-    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_json(&res).unwrap();
     assert_eq!(
         res_parsed,
         vec![
@@ -747,7 +747,7 @@ fn test_emissions_distribution_6() {
     ]));
 
     let res = query(deps.as_ref(), mock_env(), msg).unwrap();
-    let res_parsed: Vec<EmissionsDistribution> = from_binary(&res).unwrap();
+    let res_parsed: Vec<EmissionsDistribution> = from_json(&res).unwrap();
     assert_eq!(
         res_parsed,
         vec![

--- a/contracts/alliance-oracle/src/tests/test_utils.rs
+++ b/contracts/alliance-oracle/src/tests/test_utils.rs
@@ -1,6 +1,6 @@
 use alliance_protocol::alliance_oracle_types::{Config, InstantiateMsg, QueryMsg};
 use cosmwasm_std::{
-    from_binary,
+    from_json,
     testing::{mock_dependencies, mock_env, mock_info, MockApi, MockQuerier, MockStorage},
     Empty, OwnedDeps,
 };
@@ -19,7 +19,7 @@ pub fn setup_contract() -> OwnedDeps<MockStorage, MockApi, MockQuerier, Empty> {
 
     let cfg = query(deps.as_ref(), mock_env(), QueryMsg::QueryConfig {}).unwrap();
 
-    let cfg: Config = from_binary(&cfg).unwrap();
+    let cfg: Config = from_json(&cfg).unwrap();
     assert_eq!("controller_addr", cfg.controller_addr);
     assert_eq!(60, cfg.data_expiry_seconds);
 

--- a/packages/alliance-protocol/Cargo.toml
+++ b/packages/alliance-protocol/Cargo.toml
@@ -10,8 +10,8 @@ exclude = []
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cw-storage-plus = { workspace = true }
-cw-asset = { workspace = true }
+cw_asset_v2 = { workspace = true }
+cw_asset_v3 = { workspace = true }
 cw20 = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/packages/alliance-protocol/src/alliance_protocol.rs
+++ b/packages/alliance-protocol/src/alliance_protocol.rs
@@ -2,7 +2,7 @@ use crate::alliance_oracle_types::ChainId;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
 use cw20::Cw20ReceiveMsg;
-use cw_asset::{Asset, AssetInfo};
+use cw_asset_v3::{Asset, AssetInfo};
 use std::collections::{HashMap, HashSet};
 
 #[cw_serde]


### PR DESCRIPTION
This PR upgrades the cw-assets and cw-storage-plus dependencies of the alliance-hub contract in preparation to tweaks for eris' ve3-contracts.